### PR TITLE
Update jpype version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Zemberek NLP kütüphanesini Python 3 ile kullanabilmenizi sağlar.
 
 ```python
 from zemberek_python import main_libs as ml
-zemberek_api = ml.zemberek_api(libjvmpath="/usr/lib/jvm/java-8-oracle/jre/lib/amd64/server/libjvm.so",
-                            zemberekJarpath="./zemberek_python/zemberek-tum-2.0.jar").zemberek()
+zemberek_api = ml.zemberek_api(
+    libjvmpath="/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so",
+    zemberekJarpath="./zemberek_python/zemberek-tum-2.0.jar",
+).zemberek()
 
 corpus = "merhaba bu bir python zemberek denemesidir,             bu denemeden garip yazılar"
 ## kelimeyi ögelerine ayır

--- a/ornek.py
+++ b/ornek.py
@@ -1,7 +1,9 @@
 from zemberek_python import main_libs as ml
 
-zemberek_api = ml.zemberek_api(libjvmpath="/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so",
-                            zemberekJarpath="./zemberek_python/zemberek-tum-2.0.jar").zemberek()
+zemberek_api = ml.zemberek_api(
+    libjvmpath="/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so",
+    zemberekJarpath="./zemberek_python/zemberek-tum-2.0.jar",
+).zemberek()
 
 
 corpus = "merhaba bu bir python zemberek denemesidir,             bu denemeden garip yazılar"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 nltk==3.4.5
-JPype1-py3==0.5.5.2
+JPype1==1.1.2
 snowballstemmer==1.2.1

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,15 @@
 from setuptools import setup
-from pip.req import parse_requirements
+
+try:  # for pip >= 10
+    from pip._internal.req import parse_requirements
+    requirement_field_name = 'requirement'
+except ImportError:  # for pip <= 9.0.3
+    from pip.req import parse_requirements
+    requirement_field_name = 'req'
+
 install_reqs = parse_requirements("requirements.txt", session='k')
 
-reqs = [str(ir.req) for ir in install_reqs]
+reqs = [str(getattr(ir, requirement_field_name)) for ir in install_reqs]
 
 setup(
     name='zemberek_parser',

--- a/zemberek_python/main_libs.py
+++ b/zemberek_python/main_libs.py
@@ -29,11 +29,11 @@ class zemberek_api:
 
     def zemberek(self):
         try:
-
             if not jpype.isJVMStarted():
                 jpype.startJVM(jvmpath=self.libjvmpath, classpath=[self.zemberekJarpath])
             TurkiyeTurkcesi = jpype.JClass("net.zemberek.tr.yapi.TurkiyeTurkcesi")
             turkiye_turkcesi = TurkiyeTurkcesi()
+
             Zemberek = jpype.JClass("net.zemberek.erisim.Zemberek")
             zemberek_r = Zemberek(turkiye_turkcesi)
             return zemberek_r


### PR DESCRIPTION
Since [JPype1-py3](https://pypi.org/project/JPype1-py3/) has been deprecated, it can be replaced with [JPype1](https://pypi.org/project/JPype1/), from which `JPype1-py3` has been originated. `JPype1` also provides a function to find out the path of the default JVM library. That way, other utility methods for the same functionality can be dropped.